### PR TITLE
Handled unhandled exceptions when flattening objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function keyIdentity (key) {
 
 export function flatten (target, opts) {
   if (target === null || target === undefined) {
-    return target;
+    return target
   }
 
   opts = opts || {}
@@ -21,16 +21,16 @@ export function flatten (target, opts) {
   const transformKey = opts.transformKey || keyIdentity
   const output = {}
 
-  const seenObjects = new WeakSet();
+  const seenObjects = new WeakSet()
 
   function step (object, prev, currentDepth) {
     currentDepth = currentDepth || 1
 
     if (seenObjects.has(object)) {
-      throw new Error("Circular reference detected");
+      throw new Error('Circular reference detected')
     }
 
-    seenObjects.add(object);
+    seenObjects.add(object)
 
     Object.keys(object).forEach(function (key) {
       const value = object[key]
@@ -54,12 +54,12 @@ export function flatten (target, opts) {
       output[newKey] = value
     })
 
-    const symbols = Object.getOwnPropertySymbols(object);
+    const symbols = Object.getOwnPropertySymbols(object)
     symbols.forEach((symbol) => {
-      const value = object[symbol];
-      const newKey = prev ? prev + delimiter + String(symbol) : String(symbol);
-      output[newKey] = value;
-    });
+      const value = object[symbol]
+      const newKey = prev ? prev + delimiter + String(symbol) : String(symbol)
+      output[newKey] = value
+    })
   }
 
   step(target)


### PR DESCRIPTION
**Problems**

1. In a real-world application, an API response could include null values for certain fields or undefined values might appear in object fields that were not properly set. If the response is processed by the flatten function, it would result in a crash or an unhandled exception error.

**Fix**:
Added a check for undefined or null targets at the start of the flatten function.

2. Using objects that contain metadata or configuration as non-enumerable properties or use symbols to define special properties, flattening fails to include those fields. This could lead to missing data in some cases.

**Fix**
i resolved this by using Object.getOwnPropertySymbols(object) to retrieve all symbol keys from the object. For each symbol, the corresponding value is accessed, and a new key is constructed by concatenating the previous key with the symbol, using the specified delimiter. This ensures that both symbol-based and enumerable properties are included in the flattened output.

3.  Improper Handling of Circular References. Circular references are common in large datasets, for instance, when an object has child objects that reference the parent, causing self-referential structures.  The flatten function does not handle circular references. If an object contains a reference to itself, the flatten function will enter an infinite loop, causing a RangeError: Maximum call stack size exceeded.

**Fix**
Added a WeakSet to keep track of visited objects during flattening


Ensured all test cases pass